### PR TITLE
Fixed typographical error, changed abreviation to abbreviation in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You can supply an xivdb_tooltips object with settings that define the initial gl
 // Optional - Change settings (these are defaults)
 var xivdb_tooltips =
 {
-	// The language of the tooltip, please use (in quotes) capitalized abreviations. 
+	// The language of the tooltip, please use (in quotes) capitalized abbreviations. 
 	// Options: 'EN' 'FR' 'DE' and 'JP'
 	'language' : 'EN',
 	


### PR DESCRIPTION
viion, I've corrected a typographical error in the documentation of the [XIVDB-Tooltips](https://github.com/viion/XIVDB-Tooltips) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
